### PR TITLE
feat!: Reorder WjDvColumn type parameters for better ergonomics

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ requires opaque background colors or else the data from other columns will be se
 the data view is scrolled horizontally.
 
 To theme the table to your needs or otherwise make it play well with your styling framework of choice (Bootstrap, 
-Tailwind CSS, Bulma, etc.), you may style it in accordance to what is shown in the **Theming the Data View** section.
+Tailwind CSS, Bulma, etc.), you may style it in accordance to what is shown in the 
+**[Theming the Data View](#theming-the-data-view)** section.
 
 ## Quickstart
 
@@ -36,9 +37,11 @@ The only two required properties are `columns` and `data`.  The former defines t
 latter provides the data that shows in each column.  By default, the `key` property of each column is treated as the 
 key to retrieve data from the data row, but this can be overridden by providing `get` functions.
 
-Each column must have the `key` and the `text` properties.  Any other property is optional.  `key` is a unique string, 
-and by default, it is assumed to be the name of a property in the data objects given to the grid via the `data` 
-property.
+Each column must have the `key` and the `text` properties.  Any other property is optional.
+
+Each data object (the rows) must have an `id` property of type `number` or `string`, and the `wjdv` property, which is 
+an object that holds operational data for each row.  The `defineData()` function is a helper function that helps you 
+fulfill these 2 requirements.  The `id` values are meant to be unique amongst the data set.
 
 > **IMPORTANT**:  Always bind `columns` and `data`.  The data view control will mutate properties inside this data, 
 > so the best practice is to bind.
@@ -48,8 +51,7 @@ property.
     import { WjDataView, defineData } from '@wjfe/dataview';
     import { type MyDataModel } from 'path/to/my-model-types.js';
 
-    type MyDataModelGridRow = WjDvRow<MyDataModel>;
-    type MyColumn = WjDvColumn<Record<string, any>, MyDataModelGridRow>;
+    type MyColumn = WjDvColumn<MyDataModel>;
     const columns = $state<MyColumn[]>([
         {
             key: 'id',
@@ -63,8 +65,10 @@ property.
     // Obtain the data somehow.  This could be part of the results of the universal or server load() SvelteKit 
     // function, or could be obtained in non-SvelteKit projects with a fetch() call.
     const dataFromApi = getDataSomehow();
-    // Now ensure the data fulfills the requirements using "defineData":
-    let data: $state<MyDataModel[]> = defineData(dataFromApi);
+    // Now ensure the data fulfills the component requirements using "defineData":
+    let data = $state(defineData<MyDataModel>(dataFromApi));
+    // The model type here ------^^^^^^^^^^^ may not be needed if you have properly typed the `getDataSomehow()` 
+    // function or the `dataFromApi` variable.
 </script>
 
 ...
@@ -76,6 +80,9 @@ property.
 This example would render the data view with two columns, whose captions will read `ID` and `Tag`.  The data shown in 
 each column will be extracted from the `MyDataModel.id` and `MyDataModel.tagName` properties of each of the data 
 objects in the `data` array.
+
+> The `defineData()` function mutates the data for performance reasons.  It works the items directly as opposed to 
+> cloning them.  Also, the same array is returned for the same performance reasons.
 
 ## Theming the Data View
 
@@ -129,8 +136,8 @@ export type Theme = {
 };
 ```
 
-While the amount of properties are a lot, each one of them are optional.  Simply set the properties that you wish to 
-customize.  The properties that aren't set will take the default documented in the table further down this document.
+While the amount of properties is many, each one of them are optional.  Simply set the properties that you wish to 
+customize.  The properties that aren't set will take the default value documented in the table further down.
 
 For example, Bootstrap consumers might want to ensure that the data view always uses the body's background color.  In 
 this case, we could create the following theme in a `dataViewThemes.ts` (potential) file:

--- a/src/lib/WjDataView.svelte
+++ b/src/lib/WjDataView.svelte
@@ -1,27 +1,89 @@
 <script context="module" lang="ts">
+    /**
+     * Possible column alignments.
+     */
     export type ColAlignment = 'start' | 'center' | 'end';
 
+    /**
+     * Properties that `WjDataView` mutates inside the data objects's `wjdv` property.
+     * 
+     * **TIP**:  Use the `defineData()` function to easily comply with data row requirements.
+     */
     export type WjDvRowProps = {
+        /**
+         * Optional.  Boolean value that determines if the row is expanded.
+         */
         expanded?: boolean;
+        /**
+         * Optional.  Boolean value that determines if the row is selected.
+         */
         selected?: boolean;
     };
 
+    /**
+     * Type of (data) row objects being fed to the `WjDataView` component.
+     * 
+     * **TIP**:  Use the `defineData()` function to easily comply with data row requirements.
+     */
     export type WjDvRow<TRow extends Record<string, any> = Record<string, any>> = TRow & {
+        /**
+         * Mandatory row identifier that is used to key the row user interface element.
+         */
         id: string | number;
+        /**
+         * Container object for properties that the `WjDataView` component mutates during the course of its execution.
+         */
         wjdv: WjDvRowProps;
     };
 
-    export type WjDvColumn<TCol extends Record<string, any> = Record<string, any>, TRow extends Record<string, any> = Record<string, any>> = TCol & {
+    /**
+     * Type that defines the necessary and optional properties of column definition objects.
+     */
+    export type WjDvColumn<TRow extends Record<string, any> = Record<string, any>, TCol extends Record<string, any> = Record<string, any>> = TCol & {
+        /**
+         * Column's key.  A string value that is meant to be unique amongst the list of columns.  It is used to key 
+         * the rendered column elements, and if no `get` property is defined, it also serves as property name to 
+         * obtain data row data values.
+         */
         key: string;
+        /**
+         * Column's caption.
+         */
         text: string;
+        /**
+         * Optional.  Column's width, in *em*'s.  The default value is 10 em's.
+         */
         width?: number;
+        /**
+         * Optional.  Minimum column's width, in *em*'s.  The default value is 3 em's.
+         */
         minWidth?: number;
+        /**
+         * Optional.  Boolean value that indicates if the column can be resized.  The default value is `true`.
+         */
         resizable?: boolean;
+        /**
+         * Optional.  Boolean value that indicates if the column is pinned.  The default value is `false`.
+         */
         pinned?: boolean;
+        /**
+         * Optional.  Boolean value that indicates if the column is hidden.  The default value is `false`.
+        */
         hidden?: boolean;
+        /**
+         * Optional.  Column alignment.  The default value is to be unset, so no explicit alignment takes place.
+         */
         alignment?: ColAlignment;
+        /**
+         * Optional.  Prevents data to wrap to a new line.  The default value is `false`.
+         */
         noTextWrap?: boolean;
-        get?: (row: TRow) => any;
+        /**
+         * Optional.  A function that returns the data that is to be rendered in the column.
+         * @param row The data row object that is about to be rendered.
+         * @returns The data meant to be rendered for this column.
+         */
+        get?: (row: WjDvRow<TRow>) => any;
     };
 
     /**
@@ -86,7 +148,7 @@
         /**
          * Defines the columns the data view component will create.
          */
-        columns: WjDvColumn<TCol, TRow>[];
+        columns: WjDvColumn<TRow, TCol>[];
         /**
          * The data that is shown by the data view component.
          */
@@ -98,7 +160,7 @@
          * @param row Data object for the row being rendered (hence its name).
          * @param key Key of the column being rendered.
          */
-        get?: (row: TRow, key: string) => any;
+        get?: (row: WjDvRow<TRow>, key: string) => any;
         /**
          * The width for colums that don't specify its own width, in `em`'s.
          */
@@ -122,11 +184,11 @@
         /**
          * Snippet used to render the contents of header cells.
          */
-        headerCell?: Snippet<[WjDvColumn<TCol, TRow>]>;
+        headerCell?: Snippet<[WjDvColumn<TRow, TCol>]>;
         /**
          * Snippet used to render the contents of data cells.
          */
-        dataCell?: Snippet<[WjDvColumn<TCol,TRow>, WjDvRow<TRow>]>;
+        dataCell?: Snippet<[WjDvColumn<TRow, TCol>, WjDvRow<TRow>]>;
         /**
          * Snipped used to render the extra row contents of rows with the `wjdv.expanded` property set to `true`.
          */
@@ -138,7 +200,7 @@
     } = $props();
 
     type ColumnInfo = {
-        column: WjDvColumn<TCol, TRow>;
+        column: WjDvColumn<TRow, TCol>;
         left?: number;
     }
 
@@ -167,7 +229,7 @@
         return p;
     }, { accPinnedWidth: 0, accUnpinnedWidth: 0, pinned: [], unpinned: [] }));
 
-    function columnWidth(col: WjDvColumn<TCol, TRow>) {
+    function columnWidth(col: WjDvColumn<TRow, TCol>) {
         return col.width ?? defaultWidth;
     }
 </script>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -10,15 +10,13 @@
     import { demoOptions } from "./demoOptions.svelte.js";
     import { themeOptions } from "./themeOptions.svelte.js";
 
-    type PersonGridRow = WjDvRow<Person>;
-
     let {
         data,
     }: {
-        data: { data: PersonGridRow[]; }
+        data: { data: WjDvRow<Person>[]; }
     } = $props();
 
-    let columns = $state<WjDvColumn<Record<string, any>, PersonGridRow>[]>([
+    let columns = $state<WjDvColumn<Person>[]>([
         {
             key: 'control',
             text: '',

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -1,6 +1,6 @@
 import type { LoadEvent } from "@sveltejs/kit";
 import type { Person } from "../data-models.js";
-import { defineData, type WjDvRow } from "$lib/WjDataView.svelte";
+import { defineData } from "$lib/WjDataView.svelte";
 import { demoOptions } from "./demoOptions.svelte.js";
 
 export async function load(ev: LoadEvent): Promise<{ total: number; data: Person[] }> {


### PR DESCRIPTION
- Now TRow goes first, which is the more likely to always be needed.
- Fixed a couple of places where TRow was meant to be WjDvRow<TRow>
- Updated README.

BREAKING CHANGE