### PR TITLE
fix: Explicitly remove the text property from ControlColumn type

### DIFF
--- a/src/lib/WjDataView.svelte
+++ b/src/lib/WjDataView.svelte
@@ -117,7 +117,7 @@
      * + The `text` property is optional.
      */
     export type ControlColumn<TRow extends Record<string, any> = Record<string, any>, TCol extends Record<string, any> = Record<string, any>> =
-        Omit<WjDvColumn<TRow, TCol>, 'key' | 'pinned' | 'get'> & {
+        Omit<WjDvColumn<TRow, TCol>, 'key' | 'pinned' | 'get' | 'text'> & {
             text?: string;
         };
 


### PR DESCRIPTION
- Seemingly unnecessary, it appears that sometimes TS complains even with the optional override, so best to simply remove it using Omit.